### PR TITLE
join should yield item immediately if either stream is ready

### DIFF
--- a/src/join.rs
+++ b/src/join.rs
@@ -395,13 +395,13 @@ mod test {
         futures_executor::block_on(async {
             let stream1 = futures_util::stream::iter([
                 Message { serial: 1 },
-                Message { serial: 3 },
+                Message { serial: 4 },
                 Message { serial: 5 },
             ]);
 
             let stream2 = futures_util::stream::iter([
                 Message { serial: 2 },
-                Message { serial: 4 },
+                Message { serial: 3 },
                 Message { serial: 6 },
             ]);
             let mut joined = join(

--- a/src/join.rs
+++ b/src/join.rs
@@ -382,6 +382,9 @@ where
 
 #[cfg(test)]
 mod test {
+    use futures_executor::block_on;
+    use futures_util::stream::iter;
+
     use crate::join;
     use crate::FromStream;
     use crate::OrderedStreamExt;
@@ -392,14 +395,14 @@ mod test {
 
     #[test]
     fn join_two() {
-        futures_executor::block_on(async {
-            let stream1 = futures_util::stream::iter([
+        block_on(async {
+            let stream1 = iter([
                 Message { serial: 1 },
                 Message { serial: 4 },
                 Message { serial: 5 },
             ]);
 
-            let stream2 = futures_util::stream::iter([
+            let stream2 = iter([
                 Message { serial: 2 },
                 Message { serial: 3 },
                 Message { serial: 6 },

--- a/src/join.rs
+++ b/src/join.rs
@@ -382,8 +382,11 @@ where
 
 #[cfg(test)]
 mod test {
+    extern crate alloc;
+
+    use alloc::boxed::Box;
     use futures_executor::block_on;
-    use futures_util::stream::iter;
+    use futures_util::stream::{iter, once, pending};
 
     use crate::join;
     use crate::FromStream;
@@ -415,6 +418,20 @@ mod test {
                 let msg = joined.next().await.unwrap();
                 assert_eq!(msg.serial, i as u32 + 1);
             }
+        });
+    }
+
+    #[test]
+    fn join_1_pending() {
+        block_on(async {
+            let stream1 = FromStream::with_ordering(pending::<Message>(), |m| m.serial);
+            let stream2 =
+                FromStream::with_ordering(once(Box::pin(async { Message { serial: 1 } })), |m| {
+                    m.serial
+                });
+            let mut joined = join(stream1, stream2);
+            let msg = joined.next().await.unwrap();
+            assert_eq!(msg.serial, 1);
         });
     }
 }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -146,6 +146,7 @@ mod test {
     use alloc::vec::Vec;
     use core::pin::Pin;
     use futures_core::Stream;
+    use futures_util::stream::iter;
 
     #[test]
     fn join_mutiple() {
@@ -160,14 +161,14 @@ mod test {
 
             let mut logs = [
                 RemoteLogSource {
-                    stream: Box::pin(futures_util::stream::iter([
+                    stream: Box::pin(iter([
                         Message { serial: 1 },
                         Message { serial: 4 },
                         Message { serial: 5 },
                     ])),
                 },
                 RemoteLogSource {
-                    stream: Box::pin(futures_util::stream::iter([
+                    stream: Box::pin(iter([
                         Message { serial: 2 },
                         Message { serial: 3 },
                         Message { serial: 6 },

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -162,14 +162,14 @@ mod test {
                 RemoteLogSource {
                     stream: Box::pin(futures_util::stream::iter([
                         Message { serial: 1 },
-                        Message { serial: 3 },
+                        Message { serial: 4 },
                         Message { serial: 5 },
                     ])),
                 },
                 RemoteLogSource {
                     stream: Box::pin(futures_util::stream::iter([
                         Message { serial: 2 },
-                        Message { serial: 4 },
+                        Message { serial: 3 },
                         Message { serial: 6 },
                     ])),
                 },


### PR DESCRIPTION
If one of the streams is ready and the other is pending, we should just return the item from the ready stream. Otherwise, join will never resolve until both streams are ready (which could be never).
    
Fixes #12.